### PR TITLE
add all extras, tests, maintainer

### DIFF
--- a/.ci_support/linux_64_.yaml
+++ b/.ci_support/linux_64_.yaml
@@ -6,11 +6,3 @@ channel_targets:
 - conda-forge main
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
-pin_run_as_build:
-  python:
-    min_pin: x.x
-    max_pin: x.x
-python:
-- 3.10.* *_cpython
-target_platform:
-- linux-64

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @mpenkov @souravsingh @timkpaine
+* @bollwyvl @mpenkov @souravsingh @timkpaine

--- a/README.md
+++ b/README.md
@@ -35,6 +35,13 @@ Current release info
 | Name | Downloads | Version | Platforms |
 | --- | --- | --- | --- |
 | [![Conda Recipe](https://img.shields.io/badge/recipe-smart--open-green.svg)](https://anaconda.org/conda-forge/smart-open) | [![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/smart-open.svg)](https://anaconda.org/conda-forge/smart-open) | [![Conda Version](https://img.shields.io/conda/vn/conda-forge/smart-open.svg)](https://anaconda.org/conda-forge/smart-open) | [![Conda Platforms](https://img.shields.io/conda/pn/conda-forge/smart-open.svg)](https://anaconda.org/conda-forge/smart-open) |
+| [![Conda Recipe](https://img.shields.io/badge/recipe-smart--open--with--all-green.svg)](https://anaconda.org/conda-forge/smart-open-with-all) | [![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/smart-open-with-all.svg)](https://anaconda.org/conda-forge/smart-open-with-all) | [![Conda Version](https://img.shields.io/conda/vn/conda-forge/smart-open-with-all.svg)](https://anaconda.org/conda-forge/smart-open-with-all) | [![Conda Platforms](https://img.shields.io/conda/pn/conda-forge/smart-open-with-all.svg)](https://anaconda.org/conda-forge/smart-open-with-all) |
+| [![Conda Recipe](https://img.shields.io/badge/recipe-smart--open--with--azure-green.svg)](https://anaconda.org/conda-forge/smart-open-with-azure) | [![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/smart-open-with-azure.svg)](https://anaconda.org/conda-forge/smart-open-with-azure) | [![Conda Version](https://img.shields.io/conda/vn/conda-forge/smart-open-with-azure.svg)](https://anaconda.org/conda-forge/smart-open-with-azure) | [![Conda Platforms](https://img.shields.io/conda/pn/conda-forge/smart-open-with-azure.svg)](https://anaconda.org/conda-forge/smart-open-with-azure) |
+| [![Conda Recipe](https://img.shields.io/badge/recipe-smart--open--with--gcs-green.svg)](https://anaconda.org/conda-forge/smart-open-with-gcs) | [![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/smart-open-with-gcs.svg)](https://anaconda.org/conda-forge/smart-open-with-gcs) | [![Conda Version](https://img.shields.io/conda/vn/conda-forge/smart-open-with-gcs.svg)](https://anaconda.org/conda-forge/smart-open-with-gcs) | [![Conda Platforms](https://img.shields.io/conda/pn/conda-forge/smart-open-with-gcs.svg)](https://anaconda.org/conda-forge/smart-open-with-gcs) |
+| [![Conda Recipe](https://img.shields.io/badge/recipe-smart--open--with--http-green.svg)](https://anaconda.org/conda-forge/smart-open-with-http) | [![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/smart-open-with-http.svg)](https://anaconda.org/conda-forge/smart-open-with-http) | [![Conda Version](https://img.shields.io/conda/vn/conda-forge/smart-open-with-http.svg)](https://anaconda.org/conda-forge/smart-open-with-http) | [![Conda Platforms](https://img.shields.io/conda/pn/conda-forge/smart-open-with-http.svg)](https://anaconda.org/conda-forge/smart-open-with-http) |
+| [![Conda Recipe](https://img.shields.io/badge/recipe-smart--open--with--s3-green.svg)](https://anaconda.org/conda-forge/smart-open-with-s3) | [![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/smart-open-with-s3.svg)](https://anaconda.org/conda-forge/smart-open-with-s3) | [![Conda Version](https://img.shields.io/conda/vn/conda-forge/smart-open-with-s3.svg)](https://anaconda.org/conda-forge/smart-open-with-s3) | [![Conda Platforms](https://img.shields.io/conda/pn/conda-forge/smart-open-with-s3.svg)](https://anaconda.org/conda-forge/smart-open-with-s3) |
+| [![Conda Recipe](https://img.shields.io/badge/recipe-smart--open--with--ssh-green.svg)](https://anaconda.org/conda-forge/smart-open-with-ssh) | [![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/smart-open-with-ssh.svg)](https://anaconda.org/conda-forge/smart-open-with-ssh) | [![Conda Version](https://img.shields.io/conda/vn/conda-forge/smart-open-with-ssh.svg)](https://anaconda.org/conda-forge/smart-open-with-ssh) | [![Conda Platforms](https://img.shields.io/conda/pn/conda-forge/smart-open-with-ssh.svg)](https://anaconda.org/conda-forge/smart-open-with-ssh) |
+| [![Conda Recipe](https://img.shields.io/badge/recipe-smart--open--with--webhdfs-green.svg)](https://anaconda.org/conda-forge/smart-open-with-webhdfs) | [![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/smart-open-with-webhdfs.svg)](https://anaconda.org/conda-forge/smart-open-with-webhdfs) | [![Conda Version](https://img.shields.io/conda/vn/conda-forge/smart-open-with-webhdfs.svg)](https://anaconda.org/conda-forge/smart-open-with-webhdfs) | [![Conda Platforms](https://img.shields.io/conda/pn/conda-forge/smart-open-with-webhdfs.svg)](https://anaconda.org/conda-forge/smart-open-with-webhdfs) |
 | [![Conda Recipe](https://img.shields.io/badge/recipe-smart_open-green.svg)](https://anaconda.org/conda-forge/smart_open) | [![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/smart_open.svg)](https://anaconda.org/conda-forge/smart_open) | [![Conda Version](https://img.shields.io/conda/vn/conda-forge/smart_open.svg)](https://anaconda.org/conda-forge/smart_open) | [![Conda Platforms](https://img.shields.io/conda/pn/conda-forge/smart_open.svg)](https://anaconda.org/conda-forge/smart_open) |
 
 Installing smart_open
@@ -47,16 +54,16 @@ conda config --add channels conda-forge
 conda config --set channel_priority strict
 ```
 
-Once the `conda-forge` channel has been enabled, `smart-open, smart_open` can be installed with `conda`:
+Once the `conda-forge` channel has been enabled, `smart-open, smart-open-with-all, smart-open-with-azure, smart-open-with-gcs, smart-open-with-http, smart-open-with-s3, smart-open-with-ssh, smart-open-with-webhdfs, smart_open` can be installed with `conda`:
 
 ```
-conda install smart-open smart_open
+conda install smart-open smart-open-with-all smart-open-with-azure smart-open-with-gcs smart-open-with-http smart-open-with-s3 smart-open-with-ssh smart-open-with-webhdfs smart_open
 ```
 
 or with `mamba`:
 
 ```
-mamba install smart-open smart_open
+mamba install smart-open smart-open-with-all smart-open-with-azure smart-open-with-gcs smart-open-with-http smart-open-with-s3 smart-open-with-ssh smart-open-with-webhdfs smart_open
 ```
 
 It is possible to list all of the versions of `smart-open` available on your platform with `conda`:
@@ -151,6 +158,7 @@ In order to produce a uniquely identifiable distribution:
 Feedstock Maintainers
 =====================
 
+* [@bollwyvl](https://github.com/bollwyvl/)
 * [@mpenkov](https://github.com/mpenkov/)
 * [@souravsingh](https://github.com/souravsingh/)
 * [@timkpaine](https://github.com/timkpaine/)

--- a/recipe/hotfix_tests.py
+++ b/recipe/hotfix_tests.py
@@ -1,0 +1,8 @@
+import site
+import shutil
+from pathlib import Path
+
+shutil.copytree(
+    "src/smart_open/tests",
+    Path(site.getsitepackages()[0]) / "smart_open/tests"
+)

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,61 +1,223 @@
-{% set name = "smart_open" %}
 {% set version = "6.3.0" %}
-{% set sha256 = "d5238825fe9a9340645fac3d75b287c08fbb99fb2b422477de781c9f5f09e019" %}
+{% set all_pytest_args = "--cov-fail-under=36" %}
 
 package:
-  name: {{ name|lower }}
+  name: smart_open_split
   version: {{ version }}
 
 source:
-  fn: {{ name }}-{{ version }}.tar.gz
-  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: {{ sha256 }}
+  - folder: dist
+    url: https://pypi.io/packages/source/s/smart_open/smart_open-{{ version }}.tar.gz
+    sha256: d5238825fe9a9340645fac3d75b287c08fbb99fb2b422477de781c9f5f09e019
+  - folder: src
+    url: https://github.com/RaRe-Technologies/smart_open/archive/refs/tags/v{{ version }}.tar.gz
+    sha256: ffd70349ad46eca048d7dd1cce23ac1db179c9787b5fb53d0c4c37bf78b96f0d
 
 build:
   noarch: python
-  number: 0
-  script: {{ PYTHON }} -m pip install . --no-deps -vv
+  number: 1
 
 requirements:
-  build:
-    - python                                 # [build_platform != target_platform]
-    - cross-python_{{ target_platform }}     # [build_platform != target_platform]
   host:
     - python >=3.6
-    - pip
   run:
     - python >=3.6
 
-test:
-  imports:
-    - smart_open
-
 outputs:
+  # the actual package
   - name: smart_open
+    build:
+      noarch: python
+      script:
+        - cd dist && {{ PYTHON }} -m pip install . --no-deps -vv
+    requirements:
+      host:
+        - python >=3.6
+        - pip
+      run:
+        - python >=3.6
+    test:
+      imports:
+        - smart_open
+      requires:
+        - pip
+      commands:
+        - pip check
+
+  # the normalized hyphen-convention package
   - name: smart-open
     build:
       noarch: python
     requirements:
       host:
-        - python
+        - python >=3.6
+      run:
+        - python >=3.6
+        - {{ pin_subpackage("smart_open", exact=True) }}
+    test:
+      imports:
+        - smart_open
+
+  # the kitchen sink with tests
+  - name: smart-open-with-all
+    build:
+      noarch: python
+    requirements:
+      host:
+        - python >=3.6
       run:
         - {{ pin_subpackage("smart_open", exact=True) }}
+        - {{ pin_subpackage("smart-open-with-azure", exact=True) }}
+        - {{ pin_subpackage("smart-open-with-gcs", exact=True) }}
+        - {{ pin_subpackage("smart-open-with-http", exact=True) }}
+        - {{ pin_subpackage("smart-open-with-s3", exact=True) }}
+        - {{ pin_subpackage("smart-open-with-ssh", exact=True) }}
+        - {{ pin_subpackage("smart-open-with-webhdfs", exact=True) }}
+    test:
+      source_files:
+        - src/smart_open/tests
+      files:
+        - hotfix_tests.py
+      requires:
+        - moto
+        - pip
+        - pytest-cov
+        - pytest-rerunfailures
+        - responses
+      commands:
+        - pip check
+        # tests reference `smart_open.tests`, but not included in distributions
+        - python hotfix_tests.py
+        - pytest -vv src/smart_open/tests --cov=smart_open --cov-report=term-missing:skip-covered --no-cov-on-fail {{ all_pytest_args }}
+
+  # extras from here on out
+  - name: smart-open-with-azure
+    build:
+      noarch: python
+    requirements:
+      host:
+        - python >=3.6
+      run:
+        - {{ pin_subpackage("smart_open", exact=True) }}
+        - azure-common
+        - azure-core
+        - azure-storage-blob
+        - python >=3.6
+    test:
+      imports:
+        - smart_open.azure
+      requires:
+        - pip
+      commands:
+        - pip check
+
+  - name: smart-open-with-gcs
+    build:
+      noarch: python
+    requirements:
+      host:
+        - python >=3.6
+      run:
+        - {{ pin_subpackage("smart_open", exact=True) }}
+        - google-cloud-storage
+        - python >=3.6
+    test:
+      imports:
+        - smart_open.gcs
+      requires:
+        - pip
+      commands:
+        - pip check
+
+  - name: smart-open-with-http
+    build:
+      noarch: python
+    requirements:
+      host:
+        - python >=3.6
+      run:
+        - {{ pin_subpackage("smart_open", exact=True) }}
+        - python >=3.6
+        - requests
+    test:
+      imports:
+        - smart_open.http
+      requires:
+        - pip
+      commands:
+        - pip check
+
+  - name: smart-open-with-s3
+    build:
+      noarch: python
+    requirements:
+      host:
+        - python >=3.6
+      run:
+        - {{ pin_subpackage("smart_open", exact=True) }}
+        - python >=3.6
+        - boto3
+    test:
+      imports:
+        - smart_open.s3
+      requires:
+        - pip
+      commands:
+        - pip check
+
+  - name: smart-open-with-ssh
+    build:
+      noarch: python
+    requirements:
+      host:
+        - python >=3.6
+      run:
+        - {{ pin_subpackage("smart_open", exact=True) }}
+        - paramiko
+        - python >=3.6
+    test:
+      imports:
+        - smart_open.ssh
+      requires:
+        - pip
+      commands:
+        - pip check
+
+  - name: smart-open-with-webhdfs
+    build:
+      noarch: python
+    requirements:
+      host:
+        - python >=3.6
+      run:
+        - {{ pin_subpackage("smart_open", exact=True) }}
+        - python >=3.6
+        - requests
+    test:
+      imports:
+        - smart_open.webhdfs
+      requires:
+        - pip
+      commands:
+        - pip check
 
 about:
   home: https://github.com/RaRe-Technologies/smart_open
   license: MIT
   license_family: MIT
-  license_file: LICENSE
+  license_file: dist/LICENSE
   summary: Python library for efficient streaming of large files
 
   description: |
-    smart_open is a Python 3 library 
+    smart_open is a Python 3 library
     for efficient streaming of very large files
-    from/to S3, HDFS, WebHDFS or local (compressed) files. 
+    from/to S3, HDFS, WebHDFS or local (compressed) files.
   dev_url: https://github.com/RaRe-Technologies/smart_open
 
 extra:
+  feedstock-name: smart_open
   recipe-maintainers:
     - timkpaine
     - souravsingh
     - mpenkov
+    - bollwyvl


### PR DESCRIPTION
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

Notes:
- [x] updates some recipe syntax
- [x] add outputs for all of the extras
  - these depend on `smart_open`, but could also flip those so that the PyPI normalized package name is the "real" package, with the underscore package as the "legacy" name 
- [x] runs tests (with coverage) for `smart-open-with-all`
  - the motivation behind this is to catch _new_ extras being added that would either fail or cause a significant coverage change
  - including the tests (whcih are not packaged, but `import smart_open.tests`) makes the `smart-open-with-all` package almost as big as the base package... 
    - but 48k isn't going to make a huge difference vs the huge stack of deps it brings in
- [x] add self as maintainer :wave: